### PR TITLE
Add message to GraphQLError

### DIFF
--- a/codegen/src/async/AsyncGenerator.ts
+++ b/codegen/src/async/AsyncGenerator.ts
@@ -100,6 +100,7 @@ export class GraphQLError extends Error {
     constructor(errors: any) {
         super();
         this.errors = errors;
+        this.message = JSON.stringify(errors)
     }
 }
 


### PR DESCRIPTION
This will allow us to do checks like
```typescript
await expect(
  createUser(undefined, true, company.id)
).rejects
  .toThrow("Uniqueness violation");
```
where we assert a certain "type" of error is thrown.